### PR TITLE
fix: 统一导航按钮为浅紫色，修复首页标题换行，移除博客详情页重复标题

### DIFF
--- a/docs/assets/app.js
+++ b/docs/assets/app.js
@@ -1266,14 +1266,13 @@
     <span>${title}</span>
   </nav>
 
+  ${dateStr || tags ? `
   <div class="blog-post-header">
-    <h1 class="blog-post-title">${title}</h1>
-    ${dateStr || tags ? `
     <div class="blog-post-meta">
       ${dateStr ? `<span class="blog-post-date">${escHtml(dateStr)}</span>` : ''}
       ${tags ? `<div class="blog-post-tags">${tags}</div>` : ''}
-    </div>` : ''}
-  </div>
+    </div>
+  </div>` : ''}
 
   <div id="blog-post-content" style="padding:2rem;border-radius:var(--radius-xl);border:1px solid var(--border);background:var(--card)">
     <p class="text-muted">加载中...</p>

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -95,6 +95,7 @@ input { font: inherit; }
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
+  white-space: nowrap;
 }
 
 /* --- Navigation --- */
@@ -119,10 +120,12 @@ input { font: inherit; }
 }
 .nav-link:hover { background: var(--muted); color: var(--foreground); }
 .nav-link.active { color: var(--accent-foreground); background: var(--accent-bg); }
-.nav-link-submit { background: var(--warning-bg); color: var(--warning); }
-.nav-link-submit:hover { background: #fde68a; color: var(--warning); }
-.nav-link-evolution { background: var(--success-bg); color: var(--success); }
-.nav-link-evolution:hover { background: #bbf7d0; color: var(--success); }
+.nav-link-submit { background: rgba(99, 102, 241, 0.12); color: var(--accent-foreground); }
+.nav-link-submit:hover { background: rgba(99, 102, 241, 0.2); color: var(--accent-foreground); }
+.nav-link-evolution { background: rgba(99, 102, 241, 0.12); color: var(--accent-foreground); }
+.nav-link-evolution:hover { background: rgba(99, 102, 241, 0.2); color: var(--accent-foreground); }
+.nav-link-blog { background: rgba(99, 102, 241, 0.12); color: var(--accent-foreground); }
+.nav-link-blog:hover { background: rgba(99, 102, 241, 0.2); color: var(--accent-foreground); }
 .nav-right { display: flex; align-items: center; gap: 0.5rem; }
 .nav-github {
   display: none; align-items: center; gap: 0.375rem;
@@ -147,7 +150,7 @@ input { font: inherit; }
   position: absolute; inset: 0;
   background: radial-gradient(ellipse 80% 50% at 50% -20%, var(--accent-bg), transparent);
 }
-.hero-content { position: relative; padding: 4rem 0 3rem; text-align: center; max-width: 48rem; margin: 0 auto; }
+.hero-content { position: relative; padding: 4rem 0 3rem; text-align: center; max-width: 56rem; margin: 0 auto; }
 .hero h1 { font-size: 2.25rem; font-weight: 700; letter-spacing: -0.025em; margin-bottom: 1rem; color: var(--foreground); }
 @media (min-width: 640px) { .hero h1 { font-size: 3rem; } }
 .hero p { font-size: 1.125rem; margin-bottom: 2rem; color: var(--muted-foreground); }

--- a/docs/index.html
+++ b/docs/index.html
@@ -35,7 +35,7 @@
           <a class="nav-link" data-href="#agents" data-nav="agents">浏览智能体</a>
           <a class="nav-link nav-link-submit" data-href="#submit" data-nav="submit">提交技能</a>
           <a class="nav-link nav-link-evolution" data-href="#evolution" data-nav="evolution">技能自进化</a>
-          <a class="nav-link" data-href="#blog" data-nav="blog">博客</a>
+          <a class="nav-link nav-link-blog" data-href="#blog" data-nav="blog">博客</a>
         </div>
 
         <div class="nav-right">


### PR DESCRIPTION
- 提交技能、技能自进化、博客三个按钮统一使用 accent 浅紫色背景
- hero-content max-width 从 48rem 扩至 56rem，gradient-text 加 white-space:nowrap 防止标题换行
- 博客详情页移除页面级 h1 标题，只保留 markdown 内的标题

https://claude.ai/code/session_01D64pcMkJFmnGqXqD9nE7ZZ